### PR TITLE
Solved problem with redirects that return a request for an unresolved r...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var parseUrl = require('url').parse;
+var resolveUrl = require('url').resolve;
 var zlib = require('zlib');
 var protocols  = {http: require('http'), https: require('https')};
 var PassThrough = require('stream').PassThrough;
@@ -82,7 +83,7 @@ function request(method, url, options, callback) {
       if (options.followRedirects && isRedirect(res.statusCode)) {
         // prevent leakage of file handles
         res.body.resume();
-        return request(duplex ? 'GET' : method, res.headers.location, options, callback);
+        return request(duplex ? 'GET' : method, resolveUrl(urlString, res.headers.location), options, callback);
       } else {
         return callback(null, res);
       }


### PR DESCRIPTION
Hello @ForbesLindesay 

I am using this library as a dependency for sync-request for a course at university and found a bug with certain redirects that, when the location header response was a relative path, made http-basic crash as follows:

sync-request/node_modules/then-request/node_modules/http-basic/index.js:143
  var req = protocols[url.protocol.replace(/:$/, '')].request({
TypeError: Cannot call method 'replace' of null
    at request (sync-request/node_modules/then-request/node_modules/http-basic/index.js:143:36)
    at request (sync-request/node_modules/then-request/node_modules/http-basic/index.js:76:12)
    at sync-request/node_modules/then-request/node_modules/http-basic/index.js:85:16
    at ClientRequest.protocols.(anonymous function).request.on.responded (sync-request/node_modules/then-request/node_modules/http-basic/index.js:153:5)
    at ClientRequest.g (events.js:180:16)
    at ClientRequest.emit (events.js:95:17)
    at HTTPParser.parserOnIncomingClient [as onIncoming](http.js:1688:21)
    at HTTPParser.parserOnHeadersComplete [as onHeadersComplete](http.js:121:23)
    at Socket.socketOnData [as ondata](http.js:1583:20)
    at TCP.onread (net.js:527:27)

(Full paths truncated due to privacy concerns)

I solved the issue by just doing a url resolve on the location header field using the previous url.

Hope you consider it.

Cheers! 
