### PR TITLE
Preserve header casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "cache-control"
   ],
   "dependencies": {
-    "http-response-object": "^1.0.0",
-    "concat-stream": "^1.4.6"
+    "caseless": "~0.9.0",
+    "concat-stream": "^1.4.6",
+    "http-response-object": "^1.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
* Use [`caseless`](https://github.com/request/caseless) to manage header casing
* Remove `console.*` calls (I'm assuming they weren't meant to be there, happy to bring them back otherwise)

Unfortunately there are apps out there that require specific header cases. For example phantomjs. The current implementation of forcing all headers to be lower-case makes phantomjs ignore or at least misinterpret the body.

See: https://github.com/groupon-testium/webdriver-http-sync/issues/25