### PR TITLE
Maintain specified headers for redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The url as a string (e.g. `http://example.com`).  It must be fully qualified and
  - `agent` - (default: `false`) controlls keep-alive (see http://nodejs.org/api/http.html#http_http_request_options_callback)
  - `followRedirects` - (default: `false`) - if true, redirects are followed (note that this only affects the result in the callback)
  - `maxRedirects` - (default: `Infinity`) - limit the number of redirects allowed.
+ - `allowRedirectHeaders` (default: `null`) - an array of headers allowed for redirects (none if `null`).
  - `gzip` (default: `false`) - automatically accept gzip and deflate encodings.  This is kept completely transparent to the user.
  - `cache` - (default: `null`) - `'memory'` or `'file'` to use the default built in caches or you can pass your own cache implementation.
  - `timeout` (default: `false`) - times out if no response is returned within the given number of milliseconds.

--- a/index.js
+++ b/index.js
@@ -116,15 +116,22 @@ function request(method, url, options, callback) {
         if (options.maxRedirects && options.maxRedirects !== Infinity) {
           options.maxRedirects--;
         }
-        // don't maintain headers (except for "user-agent") through redirects
+        // don't maintain headers through redirects
         // This fixes a problem where a POST to http://example.com
         // might result in a GET to http://example.co.uk that includes "content-length"
         // as a header
-        var ua = caseless(options.headers).get('user-agent');
-        options.headers = {};
-        if (ua) {
-          options.headers['user-agent'] = ua;
+        var headers = caseless(options.headers), redirectHeaders = {};
+        if (options.allowRedirectHeaders) {
+          var headerName, headerValue;
+          for (var i = 0; i < options.allowRedirectHeaders.length; i++) {
+            headerName = options.allowRedirectHeaders[i];
+            headerValue = headers.get(headerName);
+            if (headerValue) {
+              redirectHeaders[headerName] = headerValue;
+            }
+          }
         }
+        options.headers = redirectHeaders;
         return request(duplex ? 'GET' : method, resolveUrl(urlString, res.headers.location), options, callback);
       } else {
         return callback(null, res);

--- a/index.js
+++ b/index.js
@@ -116,11 +116,15 @@ function request(method, url, options, callback) {
         if (options.maxRedirects && options.maxRedirects !== Infinity) {
           options.maxRedirects--;
         }
-        // don't maintain headers through redirects
+        // don't maintain headers (except for "user-agent") through redirects
         // This fixes a problem where a POST to http://example.com
         // might result in a GET to http://example.co.uk that includes "content-length"
         // as a header
+        var ua = caseless(options.headers).get('user-agent');
         options.headers = {};
+        if (ua) {
+          options.headers['user-agent'] = ua;
+        }
         return request(duplex ? 'GET' : method, resolveUrl(urlString, res.headers.location), options, callback);
       } else {
         return callback(null, res);

--- a/test/index.js
+++ b/test/index.js
@@ -79,3 +79,11 @@ request('GET', CACHED, {cache: 'file'}, function (err, res) {
     }, 1000);
   });
 });
+
+request('GET', 'https://api.github.com/repos/isaacs/npm', {followRedirects: true, headers: {'User-Agent': 'http-basic'}}, function (err, res) {
+  if (err) throw err;
+
+  console.log('response I');
+  assert(res.statusCode === 200);
+  res.body.resume();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -80,7 +80,7 @@ request('GET', CACHED, {cache: 'file'}, function (err, res) {
   });
 });
 
-request('GET', 'https://api.github.com/repos/isaacs/npm', {followRedirects: true, headers: {'User-Agent': 'http-basic'}}, function (err, res) {
+request('GET', 'https://api.github.com/repos/isaacs/npm', {allowRedirectHeaders: ['User-Agent'], followRedirects: true, headers: {'User-Agent': 'http-basic'}}, function (err, res) {
   if (err) throw err;
 
   console.log('response I');


### PR DESCRIPTION
Hey @ForbesLindesay - I ran into #4 with this code:

```js
request('GET', 'https://api.github.com/repos/isaacs/npm', {followRedirects: true, headers: {'User-Agent': 'http-basic'}}, function (err, res) {
  if (err) throw err;
  console.log(res.statusCode); // error 403
});
```

This PR fixes the issue by maintaining all original headers through redirects except for "content-length" in GET requests (which should also help with the other issue mentioned in the comment). I also added a little test.

Let me know if this works or if you'd like it to work differently. Thanks!