### PR TITLE
Support Last-Modified header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
+  - "6"
+  - "4"
   - "0.10"

--- a/index.js
+++ b/index.js
@@ -153,8 +153,13 @@ function request(method, url, options, callback) {
           res.fromCache = true;
           res.fromNotModified = false;
           return callback(null, res);
-        } else if (cachedResponse.headers['etag']) {
-          headers.set('If-None-Match', cachedResponse.headers['etag']);
+        } else {
+          if (cachedResponse.headers['etag']) {
+            headers.set('If-None-Match', cachedResponse.headers['etag']);
+          }
+          if (cachedResponse.headers['last-modified']) {
+            headers.set('If-Modified-Since', cachedResponse.headers['last-modified']);
+          }
         }
       }
       request('GET', urlString, {

--- a/lib/cache-utils.js
+++ b/lib/cache-utils.js
@@ -22,6 +22,7 @@ exports.isExpired = function (cachedResponse) {
 };
 exports.canCache = function (res) {
   if (res.headers['etag']) return true;
+  if (res.headers['last-modified']) return true;
   if (/^public\, *max\-age\=(\d+)$/.test(res.headers['cache-control'])) return true;
   if (res.statusCode === 301 || res.statusCode === 308) return true;
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
     "concat-stream": "^1.4.6",
     "http-response-object": "^1.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "rimraf": "^2.5.4",
+    "serve-static": "^1.11.1"
+  },
   "scripts": {
-    "test": "node test"
+    "test": "node test/index && node test/cache"
   },
   "repository": {
     "type": "git",

--- a/test/cache.js
+++ b/test/cache.js
@@ -75,7 +75,6 @@ var etagsServer = http.createServer(serveStatic(__dirname, {
   etag: true,
   lastModified: false,
   cacheControl: false,
-  cacheControl: false,
   fallthrough: false
 }));
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,186 @@
+'use strict';
+
+var assert = require('assert');
+var request = require('../');
+var http = require('http');
+var serveStatic = require('serve-static');
+var rimraf = require('rimraf');
+var path = require('path');
+
+rimraf.sync(path.resolve(__dirname, '..', 'cache'));
+
+
+var CACHED_BY_CACHE_CONTROL = 'http://localhost:3293/index.js';
+
+var cacheControlServer = http.createServer(serveStatic(__dirname, {
+  etag: false,
+  lastModified: false,
+  cacheControl: true,
+  maxAge: 5000,
+  fallthrough: false
+}));
+
+cacheControlServer.unref();
+
+cacheControlServer.listen(3293, function onListen() {
+  request('GET', CACHED_BY_CACHE_CONTROL, {cache: 'memory'}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response E (populate memory cache)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      request('GET', CACHED_BY_CACHE_CONTROL, {cache: 'memory'}, function (err, res) {
+        if (err) throw err;
+
+        console.log('response F (from memory cache)');
+        assert(res.statusCode === 200);
+        assert(res.fromCache === true);
+        assert(res.fromNotModified === false);
+        res.body.resume();
+      });
+    });
+  });
+
+  request('GET', CACHED_BY_CACHE_CONTROL, {cache: 'file'}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response G (populate file cache)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(function () {
+        request('GET', CACHED_BY_CACHE_CONTROL, {cache: 'file'}, function (err, res) {
+          if (err) throw err;
+
+          console.log('response H (from file cache)');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === false);
+          res.body.resume();
+        });
+      }, 1000);
+    });
+  });
+});
+
+
+var CACHED_BY_ETAGS = 'http://localhost:4294/index.js';
+
+var etagsServer = http.createServer(serveStatic(__dirname, {
+  etag: true,
+  lastModified: false,
+  cacheControl: false,
+  cacheControl: false,
+  fallthrough: false
+}));
+
+etagsServer.unref();
+
+etagsServer.listen(4294, function onListen() {
+  request('GET', CACHED_BY_ETAGS, {cache: 'memory'}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response I (populate memory cache)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      request('GET', CACHED_BY_ETAGS, {cache: 'memory'}, function (err, res) {
+        if (err) throw err;
+
+        console.log('response J (from memory cache)');
+        assert(res.statusCode === 200);
+        assert(res.fromCache === true);
+        assert(res.fromNotModified === true);
+        res.body.resume();
+      });
+    });
+  });
+
+  request('GET', CACHED_BY_ETAGS, {cache: 'file'}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response K (populate file cache)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(function () {
+        request('GET', CACHED_BY_ETAGS, {cache: 'file'}, function (err, res) {
+          if (err) throw err;
+
+          console.log('response L (from file cache)');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === true);
+          res.body.resume();
+        });
+      }, 1000);
+    });
+  });
+});
+
+
+var CACHED_BY_LAST_MODIFIED = 'http://localhost:5295/index.js';
+
+var lastModifiedServer = http.createServer(serveStatic(__dirname, {
+  etag: false,
+  lastModified: true,
+  cacheControl: false,
+  fallthrough: false
+}));
+
+lastModifiedServer.unref();
+
+lastModifiedServer.listen(5295, function onListen() {
+  request('GET', CACHED_BY_LAST_MODIFIED, {cache: 'memory'}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response M (populate memory cache)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      request('GET', CACHED_BY_LAST_MODIFIED, {cache: 'memory'}, function (err, res) {
+        if (err) throw err;
+
+        console.log('response N (from memory cache)');
+        assert(res.statusCode === 200);
+        assert(res.fromCache === true);
+        assert(res.fromNotModified === true);
+        res.body.resume();
+      });
+    });
+  });
+
+  request('GET', CACHED_BY_LAST_MODIFIED, {cache: 'file'}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response O (populate file cache)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(function () {
+        request('GET', CACHED_BY_LAST_MODIFIED, {cache: 'file'}, function (err, res) {
+          if (err) throw err;
+
+          console.log('response P (from file cache)');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === true);
+          res.body.resume();
+        });
+      }, 1000);
+    });
+  });
+});

--- a/test/cache.js
+++ b/test/cache.js
@@ -20,8 +20,6 @@ var cacheControlServer = http.createServer(serveStatic(__dirname, {
   fallthrough: false
 }));
 
-cacheControlServer.unref();
-
 cacheControlServer.listen(3293, function onListen() {
   request('GET', CACHED_BY_CACHE_CONTROL, {cache: 'memory'}, function (err, res) {
     if (err) throw err;
@@ -32,15 +30,17 @@ cacheControlServer.listen(3293, function onListen() {
     assert(res.fromNotModified === undefined);
     res.body.on('data', function () {});
     res.body.on('end', function () {
-      request('GET', CACHED_BY_CACHE_CONTROL, {cache: 'memory'}, function (err, res) {
-        if (err) throw err;
+      setTimeout(function () {
+        request('GET', CACHED_BY_CACHE_CONTROL, {cache: 'memory'}, function (err, res) {
+          if (err) throw err;
 
-        console.log('response F (from memory cache)');
-        assert(res.statusCode === 200);
-        assert(res.fromCache === true);
-        assert(res.fromNotModified === false);
-        res.body.resume();
-      });
+          console.log('response F (from memory cache)');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === false);
+          res.body.resume();
+        });
+      }, 25);
     });
   });
 
@@ -68,6 +68,8 @@ cacheControlServer.listen(3293, function onListen() {
   });
 });
 
+cacheControlServer.unref();
+
 
 var CACHED_BY_ETAGS = 'http://localhost:4294/index.js';
 
@@ -77,8 +79,6 @@ var etagsServer = http.createServer(serveStatic(__dirname, {
   cacheControl: false,
   fallthrough: false
 }));
-
-etagsServer.unref();
 
 etagsServer.listen(4294, function onListen() {
   request('GET', CACHED_BY_ETAGS, {cache: 'memory'}, function (err, res) {
@@ -90,15 +90,17 @@ etagsServer.listen(4294, function onListen() {
     assert(res.fromNotModified === undefined);
     res.body.on('data', function () {});
     res.body.on('end', function () {
-      request('GET', CACHED_BY_ETAGS, {cache: 'memory'}, function (err, res) {
-        if (err) throw err;
+      setTimeout(function () {
+        request('GET', CACHED_BY_ETAGS, {cache: 'memory'}, function (err, res) {
+          if (err) throw err;
 
-        console.log('response J (from memory cache)');
-        assert(res.statusCode === 200);
-        assert(res.fromCache === true);
-        assert(res.fromNotModified === true);
-        res.body.resume();
-      });
+          console.log('response J (from memory cache)');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === true);
+          res.body.resume();
+        });
+      }, 25);
     });
   });
 
@@ -126,6 +128,8 @@ etagsServer.listen(4294, function onListen() {
   });
 });
 
+etagsServer.unref();
+
 
 var CACHED_BY_LAST_MODIFIED = 'http://localhost:5295/index.js';
 
@@ -135,8 +139,6 @@ var lastModifiedServer = http.createServer(serveStatic(__dirname, {
   cacheControl: false,
   fallthrough: false
 }));
-
-lastModifiedServer.unref();
 
 lastModifiedServer.listen(5295, function onListen() {
   request('GET', CACHED_BY_LAST_MODIFIED, {cache: 'memory'}, function (err, res) {
@@ -148,15 +150,17 @@ lastModifiedServer.listen(5295, function onListen() {
     assert(res.fromNotModified === undefined);
     res.body.on('data', function () {});
     res.body.on('end', function () {
-      request('GET', CACHED_BY_LAST_MODIFIED, {cache: 'memory'}, function (err, res) {
-        if (err) throw err;
+    	setTimeout(function () {
+        request('GET', CACHED_BY_LAST_MODIFIED, {cache: 'memory'}, function (err, res) {
+          if (err) throw err;
 
-        console.log('response N (from memory cache)');
-        assert(res.statusCode === 200);
-        assert(res.fromCache === true);
-        assert(res.fromNotModified === true);
-        res.body.resume();
-      });
+          console.log('response N (from memory cache)');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === true);
+          res.body.resume();
+        });
+      }, 25);
     });
   });
 
@@ -183,3 +187,5 @@ lastModifiedServer.listen(5295, function onListen() {
     });
   });
 });
+
+lastModifiedServer.unref();

--- a/test/index.js
+++ b/test/index.js
@@ -36,54 +36,10 @@ request('GET', 'https://promisejs.org', {followRedirects: true}, function (err, 
   res.body.resume();
 });
 
-var CACHED = 'https://www.promisejs.org/polyfills/promise-done-1.0.0.js';
-
-request('GET', CACHED, {cache: 'memory'}, function (err, res) {
-  if (err) throw err;
-
-  console.log('response D (populate cache)');
-  assert(res.statusCode === 200);
-  res.body.on('data', function () {});
-  res.body.on('end', function () {
-    request('GET', CACHED, {cache: 'memory'}, function (err, res) {
-      if (err) throw err;
-
-      console.log('response E (from cache)');
-      assert(res.fromCache === true);
-      assert(res.fromNotModified === false);
-      assert(res.statusCode === 200);
-      res.body.resume();
-    });
-  });
-});
-
-
-
-request('GET', CACHED, {cache: 'file'}, function (err, res) {
-  if (err) throw err;
-
-  console.log('response G (populate file cache)');
-  assert(res.statusCode === 200);
-  res.body.on('data', function () {});
-  res.body.on('end', function () {
-    setTimeout(function () {
-      request('GET', CACHED, {cache: 'file'}, function (err, res) {
-        if (err) throw err;
-
-        console.log('response H (from file cache)');
-        assert(res.fromCache === true);
-        assert(res.fromNotModified === false);
-        assert(res.statusCode === 200);
-        res.body.resume();
-      });
-    }, 1000);
-  });
-});
-
 request('GET', 'https://api.github.com/repos/isaacs/npm', {allowRedirectHeaders: ['User-Agent'], followRedirects: true, headers: {'User-Agent': 'http-basic'}}, function (err, res) {
   if (err) throw err;
 
-  console.log('response I');
+  console.log('response D');
   assert(res.statusCode === 200);
   res.body.resume();
 });


### PR DESCRIPTION
This PR causes requests with the `Last-Modified` header to be cached, and retrieved with `If-Modified-Since`.

I updated the tests, so they now test `cache-control`, `etag`, and `last-modified` caching individually.

Fixes #11.