### PR TITLE
Allow more valid formats for cache-control header

### DIFF
--- a/lib/cache-control-utils.js
+++ b/lib/cache-control-utils.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var parseCacheControl = require('parse-cache-control');
+
+function parseCacheControlHeader(res){
+  var cacheControl = res.headers['cache-control'];
+  cacheControl = (cacheControl || '').trim(); // must be normalised for parsing (e.g. parseCacheControl)
+  if(!cacheControl){return null;}
+  return parseCacheControl(cacheControl);
+}
+
+// for the purposes of this library, we err on the side of caution and do not cache anything except public (or implicit public)
+var nonCaching = ['private','no-cache','no-store','no-transform','must-revalidate','proxy-revalidate'];
+
+function isCacheControlCacheable(parsedCacheControl){
+  if(!parsedCacheControl){return false;}
+  if(parsedCacheControl.public){return true;}
+  // note that the library does not currently support s-maxage
+  if(parsedCacheControl["max-age"]){
+    // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.3
+    // The max-age directive on a response implies that the response is cacheable (i.e., "public") unless some other, more restrictive cache directive is also present.
+    for(var i=0;i<nonCaching.length;i++){
+      if(parsedCacheControl[nonCaching[i]]){return false;}
+    }
+    return true;
+  }
+  return false;
+}
+
+function isCacheable(res){
+  return isCacheControlCacheable(parseCacheControlHeader(res));  
+}
+
+function buildPolicy(parsedCacheControl){
+  // note that the library does not currently support s-maxage
+  return {maxage:parsedCacheControl['max-age']};
+}
+
+function cachePolicy(res){
+  var parsed = parseCacheControlHeader(res);
+  return isCacheControlCacheable(parsed) ? buildPolicy(parsed) : null;
+}
+
+/*
+    returns true if this response is cacheable (according to cache-control headers)
+*/
+exports.isCacheable = isCacheable;
+/*
+    if the response is cacheable, returns an object detailing the maxage of the cache
+    otherwise returns null
+*/
+exports.cachePolicy = cachePolicy;

--- a/lib/cache-control-utils.js
+++ b/lib/cache-control-utils.js
@@ -2,24 +2,30 @@
 
 var parseCacheControl = require('parse-cache-control');
 
-function parseCacheControlHeader(res){
+function parseCacheControlHeader(res) {
   var cacheControl = res.headers['cache-control'];
   cacheControl = (cacheControl || '').trim(); // must be normalised for parsing (e.g. parseCacheControl)
-  if(!cacheControl){return null;}
+  if (!cacheControl) {
+    return null;
+  }
   return parseCacheControl(cacheControl);
 }
 
 // for the purposes of this library, we err on the side of caution and do not cache anything except public (or implicit public)
 var nonCaching = ['private','no-cache','no-store','no-transform','must-revalidate','proxy-revalidate'];
 
-function isCacheControlCacheable(parsedCacheControl){
-  if(!parsedCacheControl){return false;}
-  if(parsedCacheControl.public){return true;}
+function isCacheControlCacheable(parsedCacheControl) {
+  if (!parsedCacheControl) {
+    return false;
+  }
+  if (parsedCacheControl.public) {
+    return true;
+  }
   // note that the library does not currently support s-maxage
-  if(parsedCacheControl["max-age"]){
+  if (parsedCacheControl["max-age"]) {
     // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.3
     // The max-age directive on a response implies that the response is cacheable (i.e., "public") unless some other, more restrictive cache directive is also present.
-    for(var i=0;i<nonCaching.length;i++){
+    for (var i=0; i<nonCaching.length; i++) {
       if(parsedCacheControl[nonCaching[i]]){return false;}
     }
     return true;
@@ -27,13 +33,13 @@ function isCacheControlCacheable(parsedCacheControl){
   return false;
 }
 
-function isCacheable(res){
+function isCacheable(res) {
   return isCacheControlCacheable(parseCacheControlHeader(res));  
 }
 
-function buildPolicy(parsedCacheControl){
+function buildPolicy(parsedCacheControl) {
   // note that the library does not currently support s-maxage
-  return {maxage:parsedCacheControl['max-age']};
+  return {maxage: parsedCacheControl['max-age']};
 }
 
 function cachePolicy(res){

--- a/lib/cache-utils.js
+++ b/lib/cache-utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var cacheControlUtils = require('./cache-control-utils');
+
 exports.isMatch = function (requestHeaders, cachedResponse) {
   if (cachedResponse.headers['vary'] && cachedResponse.requestHeaders) {
     return cachedResponse.headers['vary'].split(',').map(function (header) { return header.trim().toLowerCase(); }).every(function (header) {
@@ -10,10 +12,10 @@ exports.isMatch = function (requestHeaders, cachedResponse) {
   }
 };
 exports.isExpired = function (cachedResponse) {
-  var match
-  if (cachedResponse.headers['cache-control'] && (match = /^public\, *max\-age\=(\d+)$/.exec(cachedResponse.headers['cache-control']))) {
+  var policy=cacheControlUtils.cachePolicy(cachedResponse);
+  if (policy) {
     var time = (Date.now() - cachedResponse.requestTimestamp) / 1000;
-    if ((+match[1]) > time) {
+    if (policy.maxage > time) {
       return false;
     }
   }
@@ -23,8 +25,7 @@ exports.isExpired = function (cachedResponse) {
 exports.canCache = function (res) {
   if (res.headers['etag']) return true;
   if (res.headers['last-modified']) return true;
-  if (/^public\, *max\-age\=(\d+)$/.test(res.headers['cache-control'])) return true;
+  if (cacheControlUtils.isCacheable(res)) return true;
   if (res.statusCode === 301 || res.statusCode === 308) return true;
-
   return false;
 };

--- a/lib/cache-utils.js
+++ b/lib/cache-utils.js
@@ -12,7 +12,7 @@ exports.isMatch = function (requestHeaders, cachedResponse) {
   }
 };
 exports.isExpired = function (cachedResponse) {
-  var policy=cacheControlUtils.cachePolicy(cachedResponse);
+  var policy = cacheControlUtils.cachePolicy(cachedResponse);
   if (policy) {
     var time = (Date.now() - cachedResponse.requestTimestamp) / 1000;
     if (policy.maxage > time) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-basic",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Very low level wrapper arround http.request/https.request",
   "keywords": [
     "http",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "caseless": "~0.11.0",
     "concat-stream": "^1.4.6",
-    "http-response-object": "^1.0.0"
+    "http-response-object": "^1.0.0",
+    "parse-cache-control": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-basic",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "Very low level wrapper arround http.request/https.request",
   "keywords": [
     "http",

--- a/test/cache.js
+++ b/test/cache.js
@@ -6,18 +6,37 @@ var http = require('http');
 var serveStatic = require('serve-static');
 var rimraf = require('rimraf');
 var path = require('path');
+var url = require('url');
+var qs = require('querystring');
 
 rimraf.sync(path.resolve(__dirname, '..', 'cache'));
 
 
 var CACHED_BY_CACHE_CONTROL = 'http://localhost:3293/index.js';
+var CACHED_BY_CACHE_CONTROL__MAX_AGE = CACHED_BY_CACHE_CONTROL +'?cache-control='+encodeURIComponent('max-age=60');
+var CACHED_BY_CACHE_CONTROL__MAX_AGE_PUBLIC = CACHED_BY_CACHE_CONTROL +'?cache-control='+encodeURIComponent('max-age=60,public');
+var CACHED_BY_CACHE_CONTROL__LWS = CACHED_BY_CACHE_CONTROL +'?cache-control='+encodeURIComponent('  public  ,  max-age=60  ');
+
+
+var overrideableHeaders = ['cache-control'];
+function overrideHeaders(res, path, stat) {
+
+  var query = qs.parse(url.parse(this.req.url).query);
+  overrideableHeaders.forEach(function(header){
+    if(header in query) {
+      res.setHeader(header,query[header]);
+    }
+  });
+  
+}
 
 var cacheControlServer = http.createServer(serveStatic(__dirname, {
   etag: false,
   lastModified: false,
   cacheControl: true,
   maxAge: 5000,
-  fallthrough: false
+  fallthrough: false,
+  setHeaders: overrideHeaders
 }));
 
 cacheControlServer.listen(3293, function onListen() {
@@ -64,6 +83,75 @@ cacheControlServer.listen(3293, function onListen() {
           res.body.resume();
         });
       }, 1000);
+    });
+  });
+
+  request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE, {cache: 'memory'}, function(err, res){
+     if (err) throw err;
+
+    console.log('response E.1 ("max-age=60")');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(function () {
+        request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE, {cache: 'memory'}, function (err, res) {
+          if (err) throw err;
+
+          console.log('response F.1 ("max-age=60")');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === false);
+          res.body.resume();
+        });
+      }, 25);
+    });
+  });
+  
+  request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE_PUBLIC, {cache: 'memory'}, function(err, res){
+     if (err) throw err;
+
+    console.log('response E.2 ("max-age=60,public)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(function () {
+        request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE_PUBLIC, {cache: 'memory'}, function (err, res) {
+          if (err) throw err;
+
+          console.log('response F.2 ("max-age=60,public)');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === false);
+          res.body.resume();
+        });
+      }, 25);
+    });
+  });
+  
+  request('GET', CACHED_BY_CACHE_CONTROL__LWS, {cache: 'memory'}, function(err, res){
+     if (err) throw err;
+
+    console.log('response E.3 ("  public  ,  max-age=60  ")');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(function () {
+        request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE_PUBLIC, {cache: 'memory'}, function (err, res) {
+          if (err) throw err;
+
+          console.log('response F.3 ("  public  ,  max-age=60  ")');
+          assert(res.statusCode === 200);
+          assert(res.fromCache === true);
+          assert(res.fromNotModified === false);
+          res.body.resume();
+        });
+      }, 25);
     });
   });
 });

--- a/test/cache.js
+++ b/test/cache.js
@@ -15,6 +15,7 @@ rimraf.sync(path.resolve(__dirname, '..', 'cache'));
 var CACHED_BY_CACHE_CONTROL = 'http://localhost:3293/index.js';
 var CACHED_BY_CACHE_CONTROL__MAX_AGE = CACHED_BY_CACHE_CONTROL +'?cache-control='+encodeURIComponent('max-age=60');
 var CACHED_BY_CACHE_CONTROL__MAX_AGE_PUBLIC = CACHED_BY_CACHE_CONTROL +'?cache-control='+encodeURIComponent('max-age=60,public');
+var CACHED_BY_CACHE_CONTROL__MAX_AGE_PRIVATE = CACHED_BY_CACHE_CONTROL +'?cache-control='+encodeURIComponent('max-age=60,private');
 var CACHED_BY_CACHE_CONTROL__LWS = CACHED_BY_CACHE_CONTROL +'?cache-control='+encodeURIComponent('  public  ,  max-age=60  ');
 
 
@@ -132,10 +133,32 @@ cacheControlServer.listen(3293, function onListen() {
     });
   });
   
+  request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE_PRIVATE, {cache: 'memory'}, function(err, res){
+     if (err) throw err;
+
+    console.log('response E.3 ("max-age=60,private)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(function () {
+        request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE_PRIVATE, {cache: 'memory'}, function (err, res) {
+          if (err) throw err;
+
+          console.log('response F.3 ("max-age=60,private)');
+          assert(res.statusCode === 200);
+          assert(!res.fromCache);
+          res.body.resume();
+        });
+      }, 25);
+    });
+  });
+  
   request('GET', CACHED_BY_CACHE_CONTROL__LWS, {cache: 'memory'}, function(err, res){
      if (err) throw err;
 
-    console.log('response E.3 ("  public  ,  max-age=60  ")');
+    console.log('response E.4 ("  public  ,  max-age=60  ")');
     assert(res.statusCode === 200);
     assert(res.fromCache === undefined);
     assert(res.fromNotModified === undefined);
@@ -145,7 +168,7 @@ cacheControlServer.listen(3293, function onListen() {
         request('GET', CACHED_BY_CACHE_CONTROL__MAX_AGE_PUBLIC, {cache: 'memory'}, function (err, res) {
           if (err) throw err;
 
-          console.log('response F.3 ("  public  ,  max-age=60  ")');
+          console.log('response F.4 ("  public  ,  max-age=60  ")');
           assert(res.statusCode === 200);
           assert(res.fromCache === true);
           assert(res.fromNotModified === false);


### PR DESCRIPTION
Fixes #13 

As suggested, I've used the parse-cache-control module to parse the header, although note:
1. the "implicit public" logic indicated by the RFC isn't implemented by that module. Instead I've added it here: https://github.com/ForbesLindesay/http-basic/compare/master...goofballLogic:master#diff-b0b65675c190325bc146c2d7867513b4R19
2. I trim the header myself since it doesn't seem to cope with leading/trailing LWS (white-space) which, (if i am not mistaken) is allowed by the spec (see https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1 "#rule")