### PR TITLE
invalidation for unsafe methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The url as a string (e.g. `http://example.com`).  It must be fully qualified and
  - `retry` (default: `false`) - retry GET requests.  Set this to `true` to retry when the request errors or returns a status code greater than or equal to 400 (can also be a function that takes `(err, req, attemptNo) => shouldRetry`)
  - `retryDelay` (default: `200`) - the delay between retries (can also be set to a function that takes `(err, res, attemptNo) => delay`)
  - `maxRetries` (default: `5`) - the number of times to retry before giving up.
+ - `ignoreFailedInvalidation` (default: `false`) - whether the cache should swallow errors if there is a problem removing a cached response. Note that enabling this setting may result in incorrect, cached data being returned to the user.
 
 **callback:**
 
@@ -65,10 +66,11 @@ Otherwise, it returns a writable stream for the body of the request.
 
 ## Implementing a Cache
 
-A `Cache` is an object with two methods:
+A `Cache` is an object with three methods:
 
  - `getResponse(url, callback)` - retrieve a cached response object
  - `setResponse(url, response)` - cache a response object
+ - `invalidateResponse(url, callback)` - remove a response which is no longer valid
 
 A cached response object is an object with the following properties:
 
@@ -81,6 +83,8 @@ A cached response object is an object with the following properties:
 `getResponse` should call the callback with an optional error and either `null` or a cached response object, depending on whether the url can be found in the cache.  Only `GET`s are cached.
 
 `setResponse` should just swallow any errors it has (or resport them using `console.warn`).
+
+`invalidateResponse` should call the callback with an optional error if it is unable to invalidate a response.
 
 A cache may also define any of the methods from `lib/cache-utils.js` to override behaviour for what gets cached.  It is currently still only possible to cache "get" requests, although this could be changed.
 

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ function request(method, url, options, callback) {
     responded = true;
     var result = new Response(res.statusCode, res.headers, res);
     result.url = urlString;
-    if (cache && unsafe && res.statusCode<400){
+    if (cache && unsafe && res.statusCode < 400){
       cache.invalidateResponse(urlString, function (err) {
         if (err && !ignoreFailedInvalidation) {
           callback(new Error('Error invalidating the cache for' + urlString + ': ' + err.message), result);

--- a/lib/file-cache.js
+++ b/lib/file-cache.js
@@ -54,6 +54,14 @@ FileCache.prototype.setResponse = function (url, response) {
     });
   });
 };
+FileCache.prototype.invalidateResponse = function (url, callback) {
+  var key = path.resolve(this._location, getCacheKey(url));
+  fs.unlink(key + '.json', function (err, res) {
+    if (err && err.code === 'ENOENT') return callback(null, null);
+    else callback(err);
+  });  
+};
+
 
 function getCacheKey(url) {
   var hash = crypto.createHash('sha512')

--- a/lib/memory-cache.js
+++ b/lib/memory-cache.js
@@ -2,7 +2,6 @@
 
 var PassThrough = require('stream').PassThrough;
 var concat = require('concat-stream');
-var Response = require('http-response-object');
 
 module.exports = MemoryCache;
 function MemoryCache() {
@@ -36,4 +35,9 @@ MemoryCache.prototype.setResponse = function (url, response) {
       requestTimestamp: response.requestTimestamp
     };
   }));
+};
+MemoryCache.prototype.invalidateResponse = function (url, callback) {
+  var cache = this._cache;
+  delete cache[url];
+  callback(null, null);
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "serve-static": "^1.11.1"
   },
   "scripts": {
-    "test": "node test/index && node test/cache"
+    "test": "node test/index && node test/cache && node test/cache-invalidation"
   },
   "repository": {
     "type": "git",

--- a/test-fixture/invalidation-failure-cache.js
+++ b/test-fixture/invalidation-failure-cache.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var MemoryCache = require('../lib/memory-cache');
+module.exports = InvalidationFailCache;
+function InvalidationFailCache(){
+    MemoryCache.call(this);
+    InvalidationFailCache.constructor = InvalidationFailCache;
+}
+InvalidationFailCache.prototype = new MemoryCache();
+InvalidationFailCache.prototype.invalidateResponse = function (url, callback) {
+    callback( new Error( 'Invalidation failed' ) );
+};

--- a/test-fixture/invalidation-failure-cache.js
+++ b/test-fixture/invalidation-failure-cache.js
@@ -8,5 +8,5 @@ function InvalidationFailCache(){
 }
 InvalidationFailCache.prototype = new MemoryCache();
 InvalidationFailCache.prototype.invalidateResponse = function (url, callback) {
-    callback( new Error( 'Invalidation failed' ) );
+    callback(new Error('Invalidation failed'));
 };

--- a/test-fixture/invalidation-failure-cache.js
+++ b/test-fixture/invalidation-failure-cache.js
@@ -1,12 +1,16 @@
 'use strict';
 
 var MemoryCache = require('../lib/memory-cache');
+
 module.exports = InvalidationFailCache;
+
 function InvalidationFailCache(){
-    MemoryCache.call(this);
-    InvalidationFailCache.constructor = InvalidationFailCache;
+  MemoryCache.call(this);
+  InvalidationFailCache.constructor = InvalidationFailCache;
 }
-InvalidationFailCache.prototype = new MemoryCache();
+InvalidationFailCache.prototype = Object.create(MemroyCache.prototype);
+InvalidationFailCache.prototype.constructor = InvalidationFailCache;
+
 InvalidationFailCache.prototype.invalidateResponse = function (url, callback) {
-    callback(new Error('Invalidation failed'));
+  callback(new Error('Invalidation failed'));
 };

--- a/test-fixture/invalidation-failure-cache.js
+++ b/test-fixture/invalidation-failure-cache.js
@@ -8,7 +8,7 @@ function InvalidationFailCache(){
   MemoryCache.call(this);
   InvalidationFailCache.constructor = InvalidationFailCache;
 }
-InvalidationFailCache.prototype = Object.create(MemroyCache.prototype);
+InvalidationFailCache.prototype = Object.create(MemoryCache.prototype);
 InvalidationFailCache.prototype.constructor = InvalidationFailCache;
 
 InvalidationFailCache.prototype.invalidateResponse = function (url, callback) {

--- a/test/cache-invalidation.js
+++ b/test/cache-invalidation.js
@@ -1,0 +1,189 @@
+'use strict';
+
+var assert = require('assert');
+var request = require('../');
+var http = require('http');
+var rimraf = require('rimraf');
+var path = require('path');
+var InvalidationFailureCache = require('../test-fixture/invalidation-failure-cache');
+
+rimraf.sync(path.resolve(__dirname, '..', 'cache'));
+
+var PORT = 3294;
+
+var cacheControlServer = http.createServer(function(req, res){
+  
+  if(req.headers["x-please-fail"]){
+    res.statusCode = 500;
+    res.end('oops');
+  } else {
+    res.statusCode = 200;
+    if(req.method === "GET"){
+      res.setHeader('cache-control','public,max-age=60');
+      res.end('These are my favourite things');
+    } else {
+      res.end();
+    }
+  }
+  
+});
+
+function resourceUri(traceId) {
+  
+  return 'http://localhost:'+PORT+'/collection-'+traceId;
+  
+}
+
+function shouldNotBeCached(traceId, cache) {
+  request('GET', resourceUri(traceId), {cache: cache}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response ' + traceId + '.2 (should no longer be cached)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    res.body.resume();
+  });
+  
+}
+
+function shouldStillBeCached(traceId, cache) {
+  request('GET', resourceUri(traceId), {cache: cache}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response ' + traceId + '.2 (should still be cached)');
+    assert(res.statusCode === 200);
+    assert(res.fromCache === true);
+    res.body.resume();
+  });
+  
+}
+
+function arrange(traceId, description, cache, callback) {
+  request('GET', resourceUri(traceId), {cache: cache}, function (err, res) {
+    if (err) throw err;
+
+    console.log('response ' + traceId + '.0 ' + description);
+    assert(res.statusCode === 200);
+    assert(res.fromCache === undefined);
+    assert(res.fromNotModified === undefined);
+    res.body.on('data', function () {});
+    res.body.on('end', function () {
+      setTimeout(callback, 25);
+    } );
+  });
+  return {
+    
+    assertIsNotCached: function() { shouldNotBeCached(traceId, cache); },
+    assertIsCached: function() { shouldStillBeCached(traceId, cache); }
+    
+  };
+  
+}
+
+function invalidationScenario(traceId, method, cacheType, isDuplex) {
+
+  var scenario = arrange(traceId, '(populate memory cache prior to ' + method + ')', cacheType, function() {
+            
+    var options = {
+      cache: cacheType,
+      headers: { 'content-type': 'text/plain' }
+    };   
+    var req = request(method, resourceUri(traceId), options, function (err, res) {
+      if (err) throw err;
+          
+      console.log('response '+traceId+'.1 ('+method+' invalidates '+cacheType+' cache)');
+      res.body.on('data', function() {});
+      res.body.on('end', function() {
+        
+        setTimeout(scenario.assertIsNotCached, 25);
+
+      });
+      
+    });
+    if(isDuplex){
+      req.end('hello world');
+    }
+
+  });
+  
+}
+
+function invalidationScenario__failedUnsafeRequest(traceId, method, cacheType, isDuplex) {
+
+  var scenario = arrange(traceId, '(populate memory cache prior to attempting ' + method + ')', cacheType, function() {
+        
+    var options = {
+      cache: cacheType,
+      headers: { 'content-type': 'text/plain', 'x-please-fail': 'true' }
+    };        
+    var req = request(method, resourceUri(traceId), options, function (err, res) {
+      if (err) throw err;
+          
+      console.log('response '+traceId+'.1 ('+method+' fails, so does not invalidate '+cacheType+' cache)');
+      res.body.on('data', function() {});
+      res.body.on('end', function() {
+        
+        setTimeout(scenario.assertIsCached, 25);
+
+      });
+      
+    });
+    if(isDuplex){
+      req.end('hello world');
+    }
+
+  });
+  
+}
+
+function invalidationScenario__failedCacheInvalidation(traceId, method, cacheObject, isDuplex, ignoreFailedInvalidation) {
+  
+  var scenario = arrange(traceId, '(populate memory cache prior to attempting ' + method + ')', cacheObject, function() {
+        
+    var options = {
+      cache: cacheObject,
+      headers: { 'content-type': 'text/plain' }
+    };
+    if(typeof ignoreFailedInvalidation === "boolean"){
+      options.ignoreFailedInvalidation = ignoreFailedInvalidation;
+    }
+    var req = request(method, resourceUri(traceId), options, function (err, res) {
+      if (ignoreFailedInvalidation && err) throw err;
+         
+      console.log('response '+traceId+'.1 (Cache invalidation fails after '+method+')');
+      res.body.on('data', function() {});
+      res.body.on('end', function() {
+        
+        setTimeout(scenario.assertIsCached, 25);
+
+      });
+      
+    });
+    if(isDuplex){
+      req.end('hello world');
+    }
+
+  });
+  
+}
+
+
+cacheControlServer.listen(PORT, function onListen() {
+
+  // unsafe methods should invalidate the cache  
+  invalidationScenario('P', 'POST', 'memory', true);
+  invalidationScenario('Q', 'POST', 'file', true);
+  invalidationScenario('R', 'PUT', 'memory', true);
+  invalidationScenario('S', 'PUT', 'file', true);
+  invalidationScenario('T', 'DELETE', 'memory', false);
+  invalidationScenario('U', 'DELETE', 'file', false);
+  // if the DELETE fails, the cache should not be invalidated
+  invalidationScenario__failedUnsafeRequest('V', 'DELETE', 'memory', false);
+  // if the cache fails to invalidate, should throw an error
+  invalidationScenario__failedCacheInvalidation('W', 'DELETE', new InvalidationFailureCache(), false, false);
+  // if the cache fails to invalidate, but the ignoreFailedInvalidation option is set, should still be cached
+  invalidationScenario__failedCacheInvalidation('X', 'DELETE', new InvalidationFailureCache(), false, true);
+  
+});
+
+cacheControlServer.unref();

--- a/test/cache-invalidation.js
+++ b/test/cache-invalidation.js
@@ -91,7 +91,7 @@ function invalidationScenario(traceId, method, cacheType, isDuplex) {
     var req = request(method, resourceUri(traceId), options, function (err, res) {
       if (err) throw err;
           
-      console.log('response '+traceId+'.1 ('+method+' invalidates '+cacheType+' cache)');
+      console.log('response '+traceId+'.1 ('+method+' invalidates ' + cacheType + ' cache)');
       res.body.on('data', function() {});
       res.body.on('end', function() {
         
@@ -119,7 +119,7 @@ function invalidationScenario__failedUnsafeRequest(traceId, method, cacheType, i
     var req = request(method, resourceUri(traceId), options, function (err, res) {
       if (err) throw err;
           
-      console.log('response '+traceId+'.1 ('+method+' fails, so does not invalidate '+cacheType+' cache)');
+      console.log('response '+traceId+'.1 ('+method+' fails, so does not invalidate ' + cacheType + ' cache)');
       res.body.on('data', function() {});
       res.body.on('end', function() {
         
@@ -150,7 +150,7 @@ function invalidationScenario__failedCacheInvalidation(traceId, method, cacheObj
     var req = request(method, resourceUri(traceId), options, function (err, res) {
       if (ignoreFailedInvalidation && err) throw err;
          
-      console.log('response '+traceId+'.1 (Cache invalidation fails after '+method+')');
+      console.log('response '+traceId+'.1 (Cache invalidation fails after ' + method + ')');
       res.body.on('data', function() {});
       res.body.on('end', function() {
         


### PR DESCRIPTION
Fixes #14 

I had to pull the tests in to a separate file as there are quite a few cases to verify. I've also included the option to ignore failures during invalidation of the cache (by default failures are _not_ ignored, and the request, as a whole, fails)