### PR TITLE
FileCache: allow custom getCacheKey

### DIFF
--- a/src/FileCache.ts
+++ b/src/FileCache.ts
@@ -17,12 +17,6 @@ function jsonParse(data: string, cb: (err: Error | null, result?: any) => void):
   cb(null, result);
 }
 
-function getCacheKey(url: string): string {
-  const hash = createHash('sha512')
-  hash.update(url)
-  return hash.digest('hex')
-}
-
 export default class FileCache implements ICache {
   private readonly _location: string;
   constructor(location: string) {
@@ -30,7 +24,7 @@ export default class FileCache implements ICache {
   }
 
   getResponse(url: string, callback: (err: null | Error, response: null | CachedResponse) => void) {
-    const key = resolve(this._location, getCacheKey(url));
+    const key = resolve(this._location, this.getCacheKey(url));
 
     fs.readFile(key + '.json', 'utf8', function (err, data) {
       if (err && err.code === 'ENOENT') return callback(null, null);
@@ -47,7 +41,7 @@ export default class FileCache implements ICache {
   }
 
   setResponse(url: string, response: CachedResponse): void {
-    const key = resolve(this._location, getCacheKey(url));
+    const key = resolve(this._location, this.getCacheKey(url));
     let errored = false;
 
     fs.mkdir(this._location, function (err) {
@@ -76,7 +70,7 @@ export default class FileCache implements ICache {
   }
 
   updateResponseHeaders(url: string, response: Pick<CachedResponse, 'headers' | 'requestTimestamp'>) {
-    const key = resolve(this._location, getCacheKey(url));
+    const key = resolve(this._location, this.getCacheKey(url));
     fs.readFile(key + '.json', 'utf8', function (err, data) {
       if (err) {
         console.warn('Error writing to cache: ' + err.message);
@@ -103,10 +97,16 @@ export default class FileCache implements ICache {
   }
 
   invalidateResponse(url: string, callback: (err: NodeJS.ErrnoException | null) => void): void {
-    const key = resolve(this._location, getCacheKey(url));
+    const key = resolve(this._location, this.getCacheKey(url));
     fs.unlink(key + '.json', (err?: NodeJS.ErrnoException | null) => {
       if (err && err.code === 'ENOENT') return callback(null);
       else callback(err || null);
     });  
+  }
+
+  getCacheKey(url: string): string {
+    const hash = createHash('sha512');
+    hash.update(url);
+    return hash.digest('hex');
   }
 }


### PR DESCRIPTION
This PR moves `getCacheKey` to the prototype of `FileCache`, so users can provide custom logic to determine which parts of the URL get used for caching. See https://github.com/ForbesLindesay/http-basic/issues/24#issuecomment-609446081 for more details.