### PR TITLE
Fix maxRedirects option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ function _request(method: HttpVerb, url: string, options: Options, callback: Cal
       headers: rawHeaders,
       agent: agent,
       followRedirects: options.followRedirects,
+      maxRedirects: options.maxRedirects,
       retry: options.retry,
       retryDelay: options.retryDelay,
       maxRetries: options.maxRetries,


### PR DESCRIPTION
Passthrough the maxRedirects option when initiating gzip request. Fixes #43.